### PR TITLE
Fixed size-links and missing-geotag handling

### DIFF
--- a/app/views/photos/show.html.erb
+++ b/app/views/photos/show.html.erb
@@ -19,20 +19,21 @@
   <u><b><%= link_to @photo.user.name, @photo.user %></b></u>, on <%= @photo.created_at.to_formatted_s(:long_ordinal) %>
 </p>
 
-<% if @photo.geo %>
+<% if @photo.geo != "" %>
 	<p>
-	  <b>Geolocation of upload:</b>
+	  <b>Geotag of upload:</b>
 	  <%= link_to @photo.geo + " (map)", "//google.com/search?q=" + @photo.geo, :target => 'new' %>
 	</p>
 <% end %>
 
 <p>
   <b>Other Sizes:</b>
-  <%= link_to "Original", @photo.image.url %> |
-  <%= link_to "Large", @photo.image.url(:large) %> |
-  <%= link_to "Medium", @photo.image.url(:medium) %> |
-  <%= link_to "Small", @photo.image.url(:small) %> |
-  <%= link_to "Thumbnail", @photo.image.url(:thumb) %>
+  <% def size_link(title, key) link_to(title, "..#{@photo.image.url(key)}") end %>
+  <%= size_link  "Original", nil %> |
+  <%= size_link  "Large", :large %> |
+  <%= size_link  "Medium", :medium %> |
+  <%= size_link  "Small", :small %> |
+  <%= size_link  "Thumbnail", :thumb %> 
 </p>
 
 <%= link_to raw('&#8592; Back'), photos_path %> |


### PR DESCRIPTION
The "Other Sizes" links are now defined relative to the current URL, so they should not break when the app root is prefixed (eg. with /photicle/).
When there is no geo data for a photo, its detail page will no longer show a map link.
